### PR TITLE
dont use separate goroutine to send tnx

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,7 +101,10 @@ func main() {
 						fmt.Println(err.Error())
 						return
 					}
-					go client.SendTransaction(context.Background(), signedTx)
+					if err := client.SendTransaction(context.Background(), signedTx); err != nil {
+						fmt.Println(err.Error())
+						return
+					}
 					fmt.Println("Send tnx succesfully...   " + strconv.Itoa(i))
 					nonce++
 				}


### PR DESCRIPTION
sending multiple txs using separate goroutine will make the non-continuous nonce and push the tnx into the txpool's queued. We want to keep the correct each account's nonce then sending tnx synchronously for each account.